### PR TITLE
Two issues in get_config_for_all_active_relays

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -48,12 +48,12 @@ async def get_relays(user_id: str) -> list[NostrRelay]:
 
 async def get_config_for_all_active_relays() -> dict:
     relays = await db.fetchall(
-        "SELECT id, meta FROM nostrrelay.relays WHERE active = true",
+        "SELECT * FROM nostrrelay.relays WHERE active = true",
         model=NostrRelay,
     )
     active_relay_configs = {}
     for relay in relays:
-        active_relay_configs[relay.id] = relay.meta.dict()
+        active_relay_configs[relay.id] = relay.meta
 
     return active_relay_configs
 


### PR DESCRIPTION
Two issues were discovered in get_config_for_all_active_relays which led to errors while loading relay configuration from the DB and that also caused the loaded meta information to be invalid. Mandatory fields for NostrRelay were not selected by the query, and a dictionary representation of the meta object should not be returned as it causes some members such as require_auth_filter and event_requires_auth to not be accessible, leading to breaking exceptions.