### PR TITLE
Fix REQ message handling to support multiple filter subscriptions

### DIFF
--- a/relay/client_connection.py
+++ b/relay/client_connection.py
@@ -115,9 +115,15 @@ class NostrClientConnection:
             await self._handle_event(event)
             return []
         if message_type == NostrEventType.REQ:
-            if len(data) != 3:
+            if len(data) < 3:
                 return []
-            return await self._handle_request(data[1], NostrFilter.parse_obj(data[2]))
+            subscription_id = data[1]
+            # Handle multiple filters in REQ message
+            responses = []
+            for filter_data in data[2:]:
+                response = await self._handle_request(subscription_id, NostrFilter.parse_obj(filter_data))
+                responses.extend(response)
+            return responses
         if message_type == NostrEventType.CLOSE:
             self._handle_close(data[1])
         if message_type == NostrEventType.AUTH:


### PR DESCRIPTION
## Problem

The nostrrelay was rejecting valid REQ messages that contained multiple filter subscriptions. This broke functionality in the nostrmarket extension, specifically the "Refresh from Nostr" feature.

## Root Cause

The relay's client connection handler was validating REQ messages with a strict check if len(data) != 3, expecting exactly 3 elements: ["REQ", subscription_id, filter].
However, according to NIP-01, REQ messages can contain multiple filters: ["REQ", subscription_id, filter1, filter2, ...].

## Impact

When users clicked "Refresh from Nostr" in the nostrmarket UI, the merchant data refresh would fail silently. Particularly, the merchant was not detecting new orders and therefore not automatically creating & sending back invoices.
  
## Nostrmarket Implementation
  Subscription Flow

  1. Frontend ([merchant-details.js:31-47](https://github.com/lnbits/nostrmarket/blob/de7fe059b856baa790f0ff3d8cf217512ce24d56/static/components/merchant-details.js#L31-L47)): Calls requeryMerchantData() which makes a GET request to /nostrmarket/api/v1/merchant/${merchantId}/nostr
  2. API Endpoint ([views_api.py:222-244](https://github.com/lnbits/nostrmarket/blob/de7fe059b856baa790f0ff3d8cf217512ce24d56/views_api.py#L222-L244)): The api_refresh_merchant function calls nostr_client.merchant_temp_subscription(merchant.public_key)
  3. Subscription Details ([nostr_client.py:98-118](https://github.com/lnbits/nostrmarket/blob/de7fe059b856baa790f0ff3d8cf217512ce24d56/nostr/nostr_client.py#L98-L118)): The merchant_temp_subscription method creates 4 different filter subscriptions:
    - Direct Messages (DMs):
    - Incoming: {"kinds": [4], "#p": [merchant_pubkey]}
    - Outgoing: {"kinds": [4], "authors": [merchant_pubkey]}
    - Stalls: {"kinds": [30017], "authors": [merchant_pubkey]}
    - Products: {"kinds": [30018], "authors": [merchant_pubkey]}
    - Profile: {"kinds": [0], "authors": [merchant_pubkey]}
    
e.g.,
```python
[
  'REQ',
  'MHe8faTayhorMdqK85m9AJ',
  {'kinds': [4], '#p': ['ce3058225f4cac2c86748fc69505b1f0498ce6d8eaed258900f746f8d548773b']},
  {'kinds': [4], 'authors': ['ce3058225f4cac2c86748fc69505b1f0498ce6d8eaed258900f746f8d548773b']},
  {'kinds': [30017], 'authors': ['ce3058225f4cac2c86748fc69505b1f0498ce6d8eaed258900f746f8d548773b']},
  {'kinds': [30018], 'authors': ['ce3058225f4cac2c86748fc69505b1f0498ce6d8eaed258900f746f8d548773b']},
  {'kinds': [0], 'authors': ['ce3058225f4cac2c86748fc69505b1f0498ce6d8eaed258900f746f8d548773b']}
]
```

  4. Subscription Properties:
    - Creates a temporary subscription with ID: "merchant-" + urlsafe_short_hash()[:32]
    - Duration: 10 seconds (default)
    - All filters use since: 0 (queries all historical events)
    - Auto-unsubscribes after 10 seconds


## Solution

  Modified relay/client_connection.py to:
  1. Change validation from len(data) != 3 to len(data) < 3 to allow multiple filters
  2. Iterate through all filters in the REQ message (data[2:])
  3. Process each filter and accumulate responses before returning

##  Testing

  - [x] Verified that single-filter REQ messages still work correctly
  - [x] Tested with nostrmarket's "Refresh from Nostr" functionality sending 4 filters in one REQ
  - [x] Confirmed all filter types (DMs, stalls, products, profile) are now properly processed

## NIP Compliance

  - [ ] Verify this change aligns with NIP-01 specification which allows multiple filters in a single REQ message.
